### PR TITLE
Added before request to stop server redirects

### DIFF
--- a/landing-page/__main__.py
+++ b/landing-page/__main__.py
@@ -1,9 +1,12 @@
-from flask import Flask
+from flask import Flask, request
+import werkzeug
 
 APP = Flask(__name__)
 SADIE1 = "assets/sadie1.jpg"
 SADIE2 = "assets/sadie2.jpg"
 CSS = "html/styles.css"
+
+WHITELIST = ["/" + endpoint + "?" for endpoint in {SADIE1, SADIE2, CSS, ""}]
 
 @APP.route("/")
 def index():
@@ -24,5 +27,13 @@ def get_sadie2():
 def get_css():
     with open(CSS) as stream:
         return stream.read()
+
+@APP.before_request
+def prevent_unexpected_endpoint_hits():
+    """ I keep getting hits from scam servers with embedded urls in the url
+        Let's prevent that by whitelisting expected endpoints
+    """
+    if request.full_path not in WHITELIST:
+        raise werkzeug.exceptions.NotFound()
 
 APP.run(host="0.0.0.0", port=80)


### PR DESCRIPTION
I keep seeing attempts to redirect my server to external sites in the logs. Since I'm not even running this as a WSGI server yet, I'll just check the request path against a whitelist of expected endpoints.