### PR TITLE
Added support for earlier versions of python

### DIFF
--- a/landing-page/__main__.py
+++ b/landing-page/__main__.py
@@ -13,17 +13,17 @@ def index():
     with open("html/index.html") as stream:
         return stream.read()
 
-@APP.route(f"/{SADIE1}")
+@APP.route("/" + SADIE1)
 def get_sadie1():
     with open(SADIE1, "rb") as stream:
         return stream.read()
 
-@APP.route(f"/{SADIE2}")
+@APP.route("/" + SADIE2)
 def get_sadie2():
     with open(SADIE2, "rb") as stream:
         return stream.read()
 
-@APP.route(f"/{CSS}")
+@APP.route("/" + CSS)
 def get_css():
     with open(CSS) as stream:
         return stream.read()


### PR DESCRIPTION
# What/Why
The version of python that I'm running on my server does not yet support f strings. So I've changed it to just use simple string concatenation to give backwards compatibility.