### PR TITLE
Added link to my gitlab deployment

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -39,6 +39,10 @@
         <input type="button" value="Register">
       </a>
     </div>
+    <p>
+        Alternatively, if you're looking for some good self-maintained code,
+        check out <a href=http://gitlab.greeson.xyz:9999/HighSaltLevels>my Gitlab Deployment</a>
+    </p>
   </div>
   <br/>
 


### PR DESCRIPTION
# What/Why
Now that I have gitlab deployed, now I can link to it from the home page