### PR TITLE
Added paragraph description to the server status

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
                             <section id="status">
                                 <div class="container">
                                     <h3>Server Statuses</h3>
+                                    <p>I have a few services running in my kubernetes cluster including the server hosting this
+                                    site (it's named "landing-page" below). To accomplish this, I created a ServiceAccount and a
+                                    ClusterRole that allows this ServiceAccount to <strong>only</strong> get, list, and watch pods
+                                    in any namespace. That way, I'm not potentially exposing any write access to my cluster on the
+                                    internet.</p>
                                     <h5>SaltBot Status</h5>
                                     <pre><code id=saltbot></code></pre>
                                     <h5>Landing Page Status</h5>


### PR DESCRIPTION
# What/Why
I realized after the fact, that I probably should have a little paragraph description on the server status explaining how I accomplished it. This PR adds that paragraph tag.