### PR TITLE
Fix Seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ package.json
 self-signed*
 
 podreader/tls.*
-podreader/tls/tls.*
+podreader/tls/*

--- a/podreader/formatter/formatter.go
+++ b/podreader/formatter/formatter.go
@@ -57,11 +57,14 @@ func createChars(char string, numChars int) string {
 	return chars
 }
 
-/* Parse the time Duration, and return the string representation.
-   i.e. 5d, 1s, 3m, etc... */
+/*
+Parse the time Duration, and return the string representation.
+
+	i.e. 5d, 1s, 3m, etc...
+*/
 func parseAge(age time.Duration) string {
 	if age.Seconds() < 60.4 {
-		return fmt.Sprintf("%.0fm", age.Seconds())
+		return fmt.Sprintf("%.0fs", age.Seconds())
 	}
 
 	if age.Minutes() < 60.4 {


### PR DESCRIPTION
# What/Why
The pod reader was mistakenly returning `m` instead of `s` which would lead people to believe that the pods have been alive for minutes when they've really only been alive for seconds. This was just an old copy/paste error that I must have missed.