### PR TITLE
Pod reader display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM node:17-alpine3.12
 
 WORKDIR /landing-page
 
-RUN npm install http-server -g
+RUN npm install http-server@13.0.2 -g
 
 COPY assets /landing-page/assets
 COPY images /landing-page/images
 COPY health favicon.ico index.html 404.html /landing-page/
 
-CMD npx http-server --cors --tls --cert /opt/tls/tls.crt --key /opt/tls/tls.key
+CMD npx http-server --cors --ssl --cert /opt/tls/tls.crt --key /opt/tls/tls.key

--- a/index.html
+++ b/index.html
@@ -135,6 +135,8 @@
                                     <pre><code id=landing-page></code></pre>
                                     <h5>Nginx Status</h5>
                                     <pre><code id=nginx></code></pre>
+                                    <h5>Pod Reader Status</h5>
+                                    <pre><code id=watchers></code></pre>
 
                                     <script type="text/javascript">
                                         function getStatus(service) {
@@ -150,6 +152,7 @@
                                         getStatus("saltbot");
                                         getStatus("landing-page");
                                         getStatus("nginx");
+                                        getStatus("watchers");
                                     </script>
                                 </div>
                             </section>


### PR DESCRIPTION
# What/Why
I thought it would be nice to also display the pod-reader status. This PR does that as well as pins the `http-server` version to one that does not crash immediately due [to this bug](https://github.com/http-party/http-server/issues/634).